### PR TITLE
Remove area datatoken from routedata

### DIFF
--- a/src/Sitecore.Mvc.Contrib/Controllers/AreaControllerRunner.cs
+++ b/src/Sitecore.Mvc.Contrib/Controllers/AreaControllerRunner.cs
@@ -59,7 +59,12 @@ namespace Sitecore.Mvc.Contrib.Controllers
             {
                 _routeData.Values["controller"] = controllerValue;
                 _routeData.Values["action"] = actionValue;
-                _routeData.DataTokens["area"] = areaValue;
+
+                // Remove area data token if not available previously to resolve null exception from App Center's TagInjectionControllerFactory's CanHandle method.
+                if (areaValue == null)
+                    _routeData.DataTokens.Remove("area");
+                else
+                    _routeData.DataTokens["area"] = areaValue;
 
                 if (UseChildActionBehavior)
                 {


### PR DESCRIPTION
Modified code checks previous 'area' value while restoring it back in the routedata, if previous value is null then remove the 'area' key from the route data otherwise routedata will have the 'area' key with null value and causes issues for subsequent controller/action execution in Siteore 7.5.
![sitecore 7 5 area controller null reference](https://cloud.githubusercontent.com/assets/3536641/5333068/837a87f8-7e63-11e4-9f7d-06c2f2562dba.PNG)

In Sitecore V7.5, Sitecore has added AppCenter area which has implementation for custom DependencyResolver (TagInjectionDependencyResolver) and ControllerFactory (TagInjectionControllerFactory), this custom controllerfactory implementation checks if controller request is for AppCenter area before passing it to MVC's implementation. While comparing the area value it throws object null exception if area value is null.

Sitecore 7.5 Method in question-
Class - TagInjectionControllerFactory 
 public bool CanHandle(RequestContext requestContext)
        {
            if (!requestContext.RouteData.DataTokens.ContainsKey("area"))
            {
                return false;
            }
            return string.Equals(requestContext.RouteData.DataTokens["area"].ToString(), this.areaName, StringComparison.InvariantCultureIgnoreCase);
        }
